### PR TITLE
Jrnker dev

### DIFF
--- a/Raptorious.SharpMt940Lib/Mt940Parser.cs
+++ b/Raptorious.SharpMt940Lib/Mt940Parser.cs
@@ -266,8 +266,8 @@ namespace Raptorious.SharpMt940Lib
                                 customerStatementMessage = customerStatementMessage.SetOpeningBalance(new TransactionBalance(transactionData, cultureInfo));
                                 break;
                             case ":61:":
-                                addAndNullTransactionIfPresent();
                                 transaction = new Transaction(transactionData, customerStatementMessage.OpeningBalance.Currency, cultureInfo);
+                                addAndNullTransactionIfPresent();
                                 break;
                             case ":86:":
                                 /* 

--- a/Raptorious.SharpMt940Lib/Transaction.cs
+++ b/Raptorious.SharpMt940Lib/Transaction.cs
@@ -119,16 +119,15 @@ namespace Raptorious.SharpMt940Lib
             {
                 throw new ArgumentNullException(nameof(cultureInfo));
             }
-            
+
 
             // TODO: Finish/Fix regex
             // @See: https://bitbucket.org/raptux/sharpmt940lib/issue/1/regex-problem-in-transactioncs
-            
+
             // not done.
             //Regex regex = new Regex(@"^(?<valuedate>(?<year>\d{2})(?<month>\d{2})(?<day>\d{2}))(?<entrydate>(?<entrymonth>\d{2})(?<entryday>\d{2}))?(?<creditdebit>C|D|RC|RD)(?<fundscode>[A-z]{0,1}?)(?<ammount>\d*,\d{0,2})(?<transactiontype>[\w\s]{4})(?<reference>[\s\w]{0,16})");
 
-            var regex = new Regex(@"^(?<valuedate>(?<year>\d{2})(?<month>\d{2})(?<day>\d{2}))(?<entrydate>(?<entrymonth>\d{2})(?<entryday>\d{2}))?(?<creditdebit>C|D|RC|RD)(?<fundscode>[A-z]{0,1}?)(?<ammount>\d*[,.]\d{0,2})(?<transactiontype>[\w\s]{4})(?<reference>[\s\w]{0,16})(?:(?<servicingreference>//[\s\w]{0,16}))*(?<supplementary>\r\n[\s\w]{0,34})*");
-
+            var regex = new Regex(@"^(?<valuedate>(?<year>\d{2})(?<month>\d{2})(?<day>\d{2}))(?<entrydate>(?<entrymonth>\d{2})(?<entryday>\d{2}))?(?<creditdebit>C|D|RC|RD)(?<fundscode>[A-z]{0,1}?)(?<ammount>\d*[,.]\d{0,2})(?<transactiontype>[\w\s]{4})(?<reference>([\s\S].+?(?=\/\/)){0,16})(?:(?<servicingreference>//[ \t\f\v\w]{0,16}))*(?<supplementary>\r\n[\s\w]{0,34})*");
 
             var match = regex.Match(data);
 


### PR DESCRIPTION
@jrnker
Bugfix: Moved addAndNullTransactionsIfPresent, as with the old setup the last transaction will be missed
@jrnker
Improvement: 
Regex now allows for , and / in reference, as per MT940 definition
Regex now allows for linebreak between servicereference and supplementary