### PR TITLE
Modified transaction regex to allow amount without decimal places.

### DIFF
--- a/Raptorious.SharpMt940Lib.Tests/TransactionTests.cs
+++ b/Raptorious.SharpMt940Lib.Tests/TransactionTests.cs
@@ -92,5 +92,13 @@ namespace Raptorious.SharpMt940Lib.Tests
 
             ExpectedSwiftTransaction.AssertTransaction(expectedTransaction, transaction);
         }
+
+        [Test]
+        public void AmountWithoutDecimalPlaces_IsParsedCorrectly()
+        {
+            var transaction = new Transaction("2012031203CR20NMSCVS0015060871", new Currency("EUR"));
+
+            Assert.AreEqual(20, transaction.Amount.Value);
+        }
     }
 }

--- a/Raptorious.SharpMt940Lib/Transaction.cs
+++ b/Raptorious.SharpMt940Lib/Transaction.cs
@@ -127,7 +127,7 @@ namespace Raptorious.SharpMt940Lib
             // not done.
             //Regex regex = new Regex(@"^(?<valuedate>(?<year>\d{2})(?<month>\d{2})(?<day>\d{2}))(?<entrydate>(?<entrymonth>\d{2})(?<entryday>\d{2}))?(?<creditdebit>C|D|RC|RD)(?<fundscode>[A-z]{0,1}?)(?<ammount>\d*,\d{0,2})(?<transactiontype>[\w\s]{4})(?<reference>[\s\w]{0,16})");
 
-            var regex = new Regex(@"^(?<valuedate>(?<year>\d{2})(?<month>\d{2})(?<day>\d{2}))(?<entrydate>(?<entrymonth>\d{2})(?<entryday>\d{2}))?(?<creditdebit>C|D|RC|RD)(?<fundscode>[A-z]{0,1}?)(?<ammount>\d*[,.]\d{0,2})(?<transactiontype>[\w\s]{4})(?<reference>[\s\w]{0,16})(?:(?<servicingreference>//[\s\w]{0,16}))*(?<supplementary>\r\n[\s\w]{0,34})*");
+            var regex = new Regex(@"^(?<valuedate>(?<year>\d{2})(?<month>\d{2})(?<day>\d{2}))(?<entrydate>(?<entrymonth>\d{2})(?<entryday>\d{2}))?(?<creditdebit>C|D|RC|RD)(?<fundscode>[A-z]{0,1})(?<ammount>\d*[,.]{0,1}\d{0,2})(?<transactiontype>[\w\s]{4})(?<reference>[\s\w]{0,16})(?:(?<servicingreference>//[\s\w]{0,16}))*(?<supplementary>\r\n[\s\w]{0,34})*");
 
 
             var match = regex.Match(data);


### PR DESCRIPTION
Given statement with the following line
`:61:2012031203CR20NMSCVS0015060871`
the parser throws
`System.Data.InvalidExpressionException: '2012031203CR20NMSCVS0015060871'`

I narrowed it down to the fact that the amount in this case does not contain the decimal separator.

As seen in the regex, the decimal separator is expected. `(?<ammount>\d*[,.]\d{0,2})`
https://github.com/mjebrahimi/SharpMt940Lib.Core/blob/937177b21612b80b5cee7e87d6c00bcb72e24add/Raptorious.SharpMt940Lib/Transaction.cs#L130

In the PR, you can see two changes to the regex:
1. removed '?' from the 'fundscode' group
2. added {0,1} to the 'ammount' group

Simply adding {0,1} to the 'ammount' group did not help, I also had to remove the '?' from the 'fundscode' group.